### PR TITLE
TRA30_DrivingRangeUpdate

### DIFF
--- a/company/TRA30_Synixe_MaldenTrainingFacility.Malden/initPlayerLocal.sqf
+++ b/company/TRA30_Synixe_MaldenTrainingFacility.Malden/initPlayerLocal.sqf
@@ -5,6 +5,7 @@ call compile preprocessFileLineNumbers "ranges\engineer.sqf";
 call compile preprocessFileLineNumbers "ranges\grenadier.sqf";
 call compile preprocessFileLineNumbers "ranges\helicopter.sqf";
 call compile preprocessFileLineNumbers "ranges\medical.sqf";
+call compile preprocessFileLineNumbers "ranges\driving.sqf";
 
 [[shop_lat_1, shop_lat_2]] call compile preprocessFileLineNumbers "ranges\lat.sqf";
 [[marksman_control]] call compile preprocessFileLineNumbers "weather.sqf";

--- a/company/TRA30_Synixe_MaldenTrainingFacility.Malden/mission.sqm
+++ b/company/TRA30_Synixe_MaldenTrainingFacility.Malden/mission.sqm
@@ -5,29 +5,29 @@ class EditorData
 	angleGridStep=0.2617994;
 	scaleGridStep=1;
 	autoGroupingDist=10;
-	toggles=1;
+	toggles=521;
 	mods[]=
 	{
 		"3denEnhanced"
 	};
 	class ItemIDProvider
 	{
-		nextID=4541;
+		nextID=5796;
 	};
 	class MarkerIDProvider
 	{
-		nextID=22;
+		nextID=25;
 	};
 	class LayerIndexProvider
 	{
-		nextID=1270;
+		nextID=1385;
 	};
 	class Camera
 	{
-		pos[]={9729.3193,42.782291,3892.2576};
-		dir[]={-0.60060215,-0.4213258,-0.6795395};
-		up[]={-0.27902356,0.90690666,-0.31569538};
-		aside[]={-0.74929088,5.7218131e-008,0.66224951};
+		pos[]={11386.147,57.713058,4204.1812};
+		dir[]={0.73163295,-0.46920925,0.4945353};
+		up[]={0.38873556,0.88308549,0.26275975};
+		aside[]={0.56000525,-1.7008279e-007,-0.82849169};
 	};
 };
 binarizationWanted=0;
@@ -164,6 +164,11 @@ addons[]=
 	"A3_Structures_F_Mil_Shelters",
 	"CUP_Weapons_Curator",
 	"CUP_Buildings_Config",
+	"A3_Props_F_Exp_Infrastructure_Traffic",
+	"CUP_WheeledVehicles_Hilux",
+	"CUP_Editor_A1_Roads_Config",
+	"CUP_CA_Config",
+	"MU_mercs",
 	"A3_Props_F_AoW_Items_Decorative",
 	"A3_Structures_F_Exp_Cultural_Cemeteries",
 	"A3_Structures_F_Exp_Commercial_FuelStation_02",
@@ -178,14 +183,13 @@ addons[]=
 	"CUP_AirVehicles_HC3",
 	"A3_Soft_F_Gamma_Hatchback_01",
 	"CUP_Misc3_Config",
-	"A3_Props_F_Argo_Civilian_InfoBoards",
-	"MU_mercs"
+	"A3_Props_F_Argo_Civilian_InfoBoards"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=79;
+		items=83;
 		class Item0
 		{
 			className="A3_Supplies_F_Heli";
@@ -587,7 +591,6 @@ class AddonsMetaData
 		{
 			className="synixe_uav";
 			name="uav";
-			author="AUTHOR";
 		};
 		class Item61
 		{
@@ -653,51 +656,73 @@ class AddonsMetaData
 		};
 		class Item71
 		{
+			className="A3_Props_F_Exp";
+			name="Arma 3 Apex - Decorative and Mission Objects";
+			author="Bohemia Interactive";
+			url="https://www.arma3.com";
+		};
+		class Item72
+		{
+			className="CUP_WheeledVehicles_Hilux";
+			name="CUP_WheeledVehicles_Hilux";
+		};
+		class Item73
+		{
+			className="CUP_Editor_A1_Roads_Config";
+			name="CUP_Editor_A1_Roads_Config";
+		};
+		class Item74
+		{
+			className="CUP_CA_Config";
+			name="CUP_CA_Config";
+		};
+		class Item75
+		{
+			className="MU_mercs";
+			name="MU_mercs";
+		};
+		class Item76
+		{
 			className="A3_Structures_F_Exp_Cultural";
 			name="Arma 3 Apex - Cultural Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item72
+		class Item77
 		{
 			className="A3_Structures_F_Exp_Commercial";
 			name="Arma 3 Apex - Commercial Buildings";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item73
+		class Item78
 		{
 			className="A3_Structures_F_Enoch_Infrastructure";
 			name="Arma 3 Contact Platform - Infrastructure Objects";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item74
+		class Item79
 		{
 			className="CUP_Misc_e_Config";
 			name="CUP_Misc_e_Config";
 		};
-		class Item75
+		class Item80
 		{
 			className="A3_Boat_F_Exp";
 			name="Arma 3 Apex - Boats and Submersibles";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item76
+		class Item81
 		{
 			className="CUP_AirVehicles_HC3";
 			name="CUP_AirVehicles_HC3";
 		};
-		class Item77
+		class Item82
 		{
 			className="CUP_Misc3_Config";
 			name="CUP_Misc3_Config";
-		};
-		class Item78
-		{
-			className="MU_mercs";
-			name="MU_mercs";
 		};
 	};
 };
@@ -1123,7 +1148,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=5;
+		items=6;
 		class Item0
 		{
 			dataType="Layer";
@@ -10858,6 +10883,57 @@ class Mission
 									dataType="Object";
 									class PositionInfo
 									{
+										position[]={11369.744,17.38662,4417.8682};
+										angles[]={0,5.7941089,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=3688;
+									type="Land_Platform_Stairs_20";
+									atlOffset=-1.6537933;
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11364.227,21.49707,4423.374};
+										angles[]={0,5.8148432,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=3692;
+									type="CargoNet_01_box_F";
+									atlOffset=0.0087337494;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="crate_client_gear_attribute_shop";
+											expression="if(_value)then{crate_client_gear_shop_boxes pushBack _this}";
+											class Value
+											{
+												class data
+												{
+													singleType="BOOL";
+													value=1;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
 										position[]={11365.671,17.110178,4424.7466};
 										angles[]={0,2.6590266,0};
 									};
@@ -10952,59 +11028,9 @@ class Mission
 										nAttributes=6;
 									};
 								};
-								class Item8
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={11369.744,17.38662,4417.8682};
-										angles[]={0,5.7941089,0};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-									};
-									id=3688;
-									type="Land_Platform_Stairs_20";
-									atlOffset=-1.6537933;
-								};
-								class Item9
-								{
-									dataType="Object";
-									class PositionInfo
-									{
-										position[]={11364.227,21.49707,4423.374};
-										angles[]={0,5.8148432,0};
-									};
-									side="Empty";
-									flags=4;
-									class Attributes
-									{
-									};
-									id=3692;
-									type="CargoNet_01_box_F";
-									class CustomAttributes
-									{
-										class Attribute0
-										{
-											property="crate_client_gear_attribute_shop";
-											expression="if(_value)then{crate_client_gear_shop_boxes pushBack _this}";
-											class Value
-											{
-												class data
-												{
-													singleType="BOOL";
-													value=1;
-												};
-											};
-										};
-										nAttributes=1;
-									};
-								};
 							};
 							id=2843;
-							atlOffset=-0.24282074;
+							atlOffset=-2.5361347;
 						};
 						class Item3
 						{
@@ -14028,7 +14054,7 @@ class Mission
 						};
 					};
 					id=2841;
-					atlOffset=5.4432049;
+					atlOffset=5.438736;
 				};
 				class Item2
 				{
@@ -34668,7 +34694,7 @@ class Mission
 								};
 							};
 							id=4492;
-							atlOffset=30.562;
+							atlOffset=96.5;
 						};
 						class Item17
 						{
@@ -34681,28 +34707,132 @@ class Mission
 						};
 					};
 					id=4174;
-					atlOffset=-5.4455929;
+					atlOffset=12.294491;
 				};
 				class Item9
 				{
 					dataType="Layer";
 					name="Personal Electronics";
 					state=1;
+					class Entities
+					{
+						items=1;
+						class Item0
+						{
+							dataType="Object";
+							class PositionInfo
+							{
+								position[]={9770.3066,39.87553,3867.9839};
+								angles[]={0,4.7128949,0};
+							};
+							side="Empty";
+							flags=4;
+							class Attributes
+							{
+							};
+							id=4538;
+							type="Box_NATO_Equip_F";
+							atlOffset=8.7738037e-005;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="ace_arsenal_attribute";
+									expression="if (!is3DEN) then {[_this, +_value] call ace_arsenal_fnc_attributeInit}";
+									class Value
+									{
+										class data
+										{
+											singleType="ARRAY";
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														singleType="ARRAY";
+														class value
+														{
+															items=4;
+															class Item0
+															{
+																class data
+																{
+																	singleType="STRING";
+																	value="ACE_microDAGR";
+																};
+															};
+															class Item1
+															{
+																class data
+																{
+																	singleType="STRING";
+																	value="ACE_DAGR";
+																};
+															};
+															class Item2
+															{
+																class data
+																{
+																	singleType="STRING";
+																	value="ACE_Vector";
+																};
+															};
+															class Item3
+															{
+																class data
+																{
+																	singleType="STRING";
+																	value="ACE_VectorDay";
+																};
+															};
+														};
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														singleType="SCALAR";
+														value=0;
+													};
+												};
+											};
+										};
+									};
+								};
+								class Attribute1
+								{
+									property="ammoBox";
+									expression="[_this,_value] call bis_fnc_initAmmoBox;";
+									class Value
+									{
+										class data
+										{
+											singleType="STRING";
+											value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
+										};
+									};
+								};
+								nAttributes=2;
+							};
+						};
+					};
 					id=4539;
-					atlOffset=96.5;
+					atlOffset=8.7738037e-005;
 				};
 			};
 			id=3564;
-			atlOffset=-8.3204393;
+			atlOffset=34.103783;
 		};
 		class Item2
 		{
 			dataType="Layer";
 			name="Ranges";
-			state=1;
 			class Entities
 			{
-				items=4;
+				items=5;
 				class Item0
 				{
 					dataType="Layer";
@@ -48005,9 +48135,7644 @@ class Mission
 					id=4434;
 					atlOffset=1.215292;
 				};
+				class Item4
+				{
+					dataType="Layer";
+					name="Driving";
+					class Entities
+					{
+						items=7;
+						class Item0
+						{
+							dataType="Layer";
+							name="Cones";
+							class Entities
+							{
+								items=336;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11421.063,27.982342,4216.0342};
+										angles[]={0.095706634,5.8978786,0.071080439};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5319;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0026950836;
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11419.362,27.221189,4220.6396};
+										angles[]={0.1758173,5.9190249,0.0095009822};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5320;
+									type="Land_RoadCone_01_F";
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11454.428,23.279709,4233.5518};
+										angles[]={0.10204422,5.9342642,6.2224603};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5321;
+									type="Land_RoadCone_01_F";
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.076,23.689432,4228.5488};
+										angles[]={0.10125301,5.9339991,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5322;
+									type="Land_RoadCone_01_F";
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11497.964,22.979504,4243.5864};
+										angles[]={0.1453668,5.9339991,0.022394964};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5328;
+									type="Land_RoadCone_01_F";
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11496.315,22.210155,4248.5894};
+										angles[]={0.1453668,5.9342642,0.022394964};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5329;
+									type="Land_RoadCone_01_F";
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11533.966,22.801409,4261.6733};
+										angles[]={0.035984326,5.9342642,6.1962051};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5339;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00011825562;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11535.614,22.837803,4256.6704};
+										angles[]={0.035984326,5.9339991,6.1962051};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5340;
+									type="Land_RoadCone_01_F";
+									atlOffset=-6.4849854e-005;
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11536.257,22.579033,4262.4556};
+										angles[]={0.035984326,5.9342642,6.1962051};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5341;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0054550171;
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11537.905,22.61562,4257.4526};
+										angles[]={0.035984326,5.9339991,6.1969991};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5342;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0054454803;
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11538.738,22.29215,4263.2822};
+										angles[]={0.052751794,5.9342642,6.1732311};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5343;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0053939819;
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11540.387,22.371426,4258.2793};
+										angles[]={0.035984326,5.9339991,6.1969991};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5344;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0053749084;
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11541.279,22.129292,4261.2285};
+										angles[]={0.059927464,5.9342642,6.1732306};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5345;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0052661896;
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11540.549,22.064802,4263.8027};
+										angles[]={0.052751794,5.9342642,6.1732311};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5346;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0053920746;
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11542.197,22.173672,4258.7998};
+										angles[]={0.059927464,5.9339991,6.1732306};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5347;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0053291321;
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.953,26.104443,4229.6128};
+										angles[]={0.080624484,5.8978786,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5353;
+									type="Land_RoadCone_01_F";
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11414.253,25.752647,4234.2183};
+										angles[]={0.080624484,5.9190249,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5354;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026416779;
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11416.965,26.061958,4230.0083};
+										angles[]={0.080624484,5.8978786,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5355;
+									type="Land_RoadCone_01_F";
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.265,25.705578,4234.6138};
+										angles[]={0.080624484,5.9190249,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5356;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0019435883;
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.82,26.026739,4230.3101};
+										angles[]={0.080624484,5.8978786,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5357;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0019454956;
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11416.12,25.606773,4234.9155};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5358;
+									type="Land_RoadCone_01_F";
+									atlOffset=2.2888184e-005;
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11418.719,25.986509,4230.7163};
+										angles[]={0.080624484,5.8978786,6.2727814};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5361;
+									type="Land_RoadCone_01_F";
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.019,25.476389,4235.3218};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5362;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026397705;
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11419.73,25.889936,4231.1118};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5363;
+									type="Land_RoadCone_01_F";
+								};
+								class Item24
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11418.03,25.333378,4235.7173};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5364;
+									type="Land_RoadCone_01_F";
+								};
+								class Item25
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.586,25.776134,4231.4136};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5365;
+									type="Land_RoadCone_01_F";
+								};
+								class Item26
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11418.886,25.219517,4236.019};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5366;
+									type="Land_RoadCone_01_F";
+								};
+								class Item27
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11421.63,25.634577,4231.7998};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5367;
+									type="Land_RoadCone_01_F";
+								};
+								class Item28
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11419.93,25.08054,4236.4053};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5368;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026416779;
+								};
+								class Item29
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.642,25.494148,4232.1953};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5369;
+									type="Land_RoadCone_01_F";
+								};
+								class Item30
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.941,24.937469,4236.8008};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5370;
+									type="Land_RoadCone_01_F";
+								};
+								class Item31
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.497,25.380285,4232.4971};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5371;
+									type="Land_RoadCone_01_F";
+								};
+								class Item32
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11421.797,24.823668,4237.1025};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5372;
+									type="Land_RoadCone_01_F";
+								};
+								class Item33
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.396,25.247345,4232.9033};
+										angles[]={0.14928113,5.8978786,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5373;
+									type="Land_RoadCone_01_F";
+									atlOffset=6.1035156e-005;
+								};
+								class Item34
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.695,24.693306,4237.5088};
+										angles[]={0.14928113,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5374;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026168823;
+								};
+								class Item35
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.407,25.099804,4233.2988};
+										angles[]={0.14928113,5.8978786,6.1843085};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5375;
+									type="Land_RoadCone_01_F";
+								};
+								class Item36
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.707,24.55381,4237.9043};
+										angles[]={0.13909568,5.9190249,6.2033553};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5376;
+									type="Land_RoadCone_01_F";
+									atlOffset=-6.1035156e-005;
+								};
+								class Item37
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11426.263,24.96958,4233.6006};
+										angles[]={0.14928113,5.8978786,6.1843085};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5377;
+									type="Land_RoadCone_01_F";
+								};
+								class Item38
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.563,24.446648,4238.2061};
+										angles[]={0.11942901,5.9190249,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5378;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00017547607;
+								};
+								class Item39
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.147,24.371332,4238.5391};
+										angles[]={0.11942901,5.8019185,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5379;
+									type="Land_RoadCone_01_F";
+									atlOffset=5.1498413e-005;
+								};
+								class Item40
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11426.986,24.855759,4233.8799};
+										angles[]={0.14928113,5.7810702,6.1843085};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5380;
+									type="Land_RoadCone_01_F";
+								};
+								class Item41
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11427.718,24.715237,4234.3291};
+										angles[]={0.14928113,5.7810702,6.1843085};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5383;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0004901886;
+								};
+								class Item42
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.385,24.598604,4234.8052};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5384;
+									type="Land_RoadCone_01_F";
+								};
+								class Item43
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.939,24.505623,4235.2969};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5385;
+									type="Land_RoadCone_01_F";
+								};
+								class Item44
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11429.655,24.385616,4235.9316};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5386;
+									type="Land_RoadCone_01_F";
+								};
+								class Item45
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.299,24.282476,4236.4614};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5387;
+									type="Land_RoadCone_01_F";
+								};
+								class Item46
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.914,24.172796,4237.063};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5388;
+									type="Land_RoadCone_01_F";
+								};
+								class Item47
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11431.659,24.123396,4237.0728};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5389;
+									type="Land_RoadCone_01_F";
+								};
+								class Item48
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11432.473,24.061882,4237.1484};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5390;
+									type="Land_RoadCone_01_F";
+								};
+								class Item49
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11433.214,24.025251,4237.0503};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5391;
+									type="Land_RoadCone_01_F";
+								};
+								class Item50
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11434.092,23.971888,4237.02};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5392;
+									type="Land_RoadCone_01_F";
+								};
+								class Item51
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11434.886,23.918873,4237.0332};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5393;
+									type="Land_RoadCone_01_F";
+								};
+								class Item52
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.769,23.859415,4237.0527};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5394;
+									type="Land_RoadCone_01_F";
+								};
+								class Item53
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11436.736,23.804825,4236.9829};
+										angles[]={0.11548356,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5395;
+									type="Land_RoadCone_01_F";
+								};
+								class Item54
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11426.696,24.131685,4239.6982};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5396;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00016593933;
+								};
+								class Item55
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11427.412,24.009277,4240.333};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5397;
+									type="Land_RoadCone_01_F";
+									atlOffset=2.0980835e-005;
+								};
+								class Item56
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.056,23.903969,4240.8628};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5398;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.8610229e-005;
+								};
+								class Item57
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.671,23.79191,4241.4644};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5399;
+									type="Land_RoadCone_01_F";
+								};
+								class Item58
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11429.416,23.742468,4241.4741};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5400;
+									type="Land_RoadCone_01_F";
+								};
+								class Item59
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.229,23.680655,4241.5498};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5401;
+									type="Land_RoadCone_01_F";
+									atlOffset=-9.9182129e-005;
+								};
+								class Item60
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.971,23.644413,4241.4517};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5402;
+									type="Land_RoadCone_01_F";
+								};
+								class Item61
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11431.849,23.591173,4241.4214};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5403;
+									type="Land_RoadCone_01_F";
+								};
+								class Item62
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11432.643,23.538155,4241.4346};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5404;
+									type="Land_RoadCone_01_F";
+								};
+								class Item63
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11433.525,23.478569,4241.4541};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5405;
+									type="Land_RoadCone_01_F";
+								};
+								class Item64
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11434.493,23.417204,4241.3843};
+										angles[]={0.12809503,5.7810702,6.2097178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5406;
+									type="Land_RoadCone_01_F";
+									atlOffset=-4.196167e-005;
+								};
+								class Item65
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.935,24.243263,4239.1807};
+										angles[]={0.11942901,5.7810702,6.2184763};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5407;
+									type="Land_RoadCone_01_F";
+								};
+								class Item66
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.37,23.316515,4241.6655};
+										angles[]={0.12809503,5.7810702,6.2097178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5408;
+									type="Land_RoadCone_01_F";
+								};
+								class Item67
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11436.319,23.210796,4241.9438};
+										angles[]={0.12809503,5.7810702,6.2097178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5409;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item68
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11437.282,23.105383,4242.2114};
+										angles[]={0.12809503,5.7810702,6.2097178};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5410;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item69
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11438.033,23.014772,4242.603};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5411;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item70
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11438.768,22.907501,4243.1851};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5412;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item71
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.444,22.81007,4243.7104};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5413;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item72
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.199,22.720186,4244.1504};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5414;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item73
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.955,22.642437,4244.4961};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5415;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item74
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11441.521,22.585329,4244.7461};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5416;
+									type="Land_RoadCone_01_F";
+									atlOffset=6.8664551e-005;
+								};
+								class Item75
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11442.349,22.520672,4244.9653};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5417;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item76
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.218,22.44059,4245.2783};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5418;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item77
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.931,22.383474,4245.4673};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5419;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item78
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11444.723,22.307568,4245.7725};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5420;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item79
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.231,22.177961,4246.5884};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5421;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item80
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.426,22.075918,4247.3027};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5422;
+									type="Land_RoadCone_01_F";
+								};
+								class Item81
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.847,21.955387,4248.0801};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5423;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item82
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.024,23.607725,4237.6602};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5424;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00010871887;
+								};
+								class Item83
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.775,23.524199,4238.0518};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5425;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00014305115;
+								};
+								class Item84
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.51,23.416927,4238.6338};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5426;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00011062622;
+								};
+								class Item85
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11441.187,23.319605,4239.1592};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5427;
+									type="Land_RoadCone_01_F";
+								};
+								class Item86
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11441.941,23.229753,4239.5991};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5428;
+									type="Land_RoadCone_01_F";
+								};
+								class Item87
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11442.697,23.151972,4239.9448};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5429;
+									type="Land_RoadCone_01_F";
+								};
+								class Item88
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.263,23.094866,4240.1948};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5430;
+									type="Land_RoadCone_01_F";
+								};
+								class Item89
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11444.091,23.030191,4240.4141};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5431;
+									type="Land_RoadCone_01_F";
+								};
+								class Item90
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11444.96,22.951633,4240.7271};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5432;
+									type="Land_RoadCone_01_F";
+								};
+								class Item91
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.673,22.895958,4240.916};
+										angles[]={0.12809503,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5433;
+									type="Land_RoadCone_01_F";
+								};
+								class Item92
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11446.465,22.821625,4241.2212};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5434;
+									type="Land_RoadCone_01_F";
+									atlOffset=2.8610229e-005;
+								};
+								class Item93
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11448.591,22.620848,4242.0171};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5435;
+									type="Land_RoadCone_01_F";
+									atlOffset=-7.6293945e-006;
+								};
+								class Item94
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11448.785,22.518892,4242.7314};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5436;
+									type="Land_RoadCone_01_F";
+									atlOffset=2.8610229e-005;
+								};
+								class Item95
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11449.206,22.39831,4243.5088};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5437;
+									type="Land_RoadCone_01_F";
+									atlOffset=2.6702881e-005;
+								};
+								class Item96
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11437.59,23.736343,4237.0991};
+										angles[]={0.11548408,5.7810702,6.2248516};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5438;
+									type="Land_RoadCone_01_F";
+									atlOffset=-4.9591064e-005;
+								};
+								class Item97
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11438.34,23.672739,4237.3477};
+										angles[]={0.10125242,5.7810702,6.2392135};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5439;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item98
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11447.294,22.78043,4241.2471};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5440;
+									type="Land_RoadCone_01_F";
+								};
+								class Item99
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11447.986,22.713078,4241.5215};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5441;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item100
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11450.033,22.294987,4244.0103};
+										angles[]={0.1296681,5.8978786,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5442;
+									type="Land_RoadCone_01_F";
+									atlOffset=-4.5776367e-005;
+								};
+								class Item101
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11448.333,21.770084,4248.6157};
+										angles[]={0.12966856,5.9190249,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5443;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0021133423;
+								};
+								class Item102
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11451.045,22.181894,4244.4058};
+										angles[]={0.1296681,5.8978786,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5444;
+									type="Land_RoadCone_01_F";
+									atlOffset=-4.5776367e-005;
+								};
+								class Item103
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11449.345,21.669729,4249.0112};
+										angles[]={0.12966856,5.9190249,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5445;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0047550201;
+								};
+								class Item104
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11451.9,22.090548,4244.7075};
+										angles[]={0.1296681,5.8978786,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5446;
+									type="Land_RoadCone_01_F";
+								};
+								class Item105
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11450.2,21.588585,4249.313};
+										angles[]={0.1296681,5.9190249,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5447;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0048027039;
+								};
+								class Item106
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11452.799,21.982975,4245.1138};
+										angles[]={0.1296681,5.8978786,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5448;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item107
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11451.099,21.532959,4249.7192};
+										angles[]={0.069487326,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5449;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00069046021;
+								};
+								class Item108
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11453.811,21.869883,4245.5093};
+										angles[]={0.1296681,5.8978786,6.2224593};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5450;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item109
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11452.11,21.511703,4250.1147};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5451;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item110
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11454.666,21.804277,4245.811};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5452;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item111
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11452.966,21.511703,4250.4165};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5453;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item112
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11455.71,21.777382,4246.1973};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5454;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item113
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11454.01,21.514345,4250.8027};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5455;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026435852;
+								};
+								class Item114
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.722,21.749876,4246.5928};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5456;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item115
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11455.021,21.511703,4251.1982};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5457;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item116
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11457.577,21.728876,4246.8945};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5458;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item117
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11455.877,21.511703,4251.5};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5459;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item118
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11458.476,21.7006,4247.3008};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5460;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item119
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.775,21.514343,4251.9063};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5461;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0026416779;
+								};
+								class Item120
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11459.487,21.673067,4247.6963};
+										angles[]={0.069487326,5.8978786,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5462;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item121
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11457.787,21.511705,4252.3018};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5463;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item122
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11446.74,21.844261,4248.6196};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5464;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item123
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11447.503,21.838705,4248.396};
+										angles[]={0.12966856,5.7810702,6.2376165};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5465;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item124
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11458.775,21.511705,4252.5952};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5466;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item125
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11459.613,21.511705,4252.6113};
+										angles[]={0,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5467;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item126
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11460.345,21.4881,4252.7627};
+										angles[]={0.039979152,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5468;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item127
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.091,21.454988,4252.8442};
+										angles[]={0.039979152,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5469;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item128
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.743,21.427279,4252.8848};
+										angles[]={0.039979152,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5470;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item129
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.405,21.399157,4252.9253};
+										angles[]={0.039979152,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5471;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item130
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.094,21.394648,4252.9351};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5472;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item131
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.788,21.392771,4252.9819};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5473;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item132
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11464.474,21.389688,4253.0591};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5474;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item133
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.134,21.39123,4253.0205};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5475;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item134
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.899,21.392908,4252.9785};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5476;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item135
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.607,21.370306,4253.5435};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5477;
+									type="Land_RoadCone_01_F";
+								};
+								class Item136
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.161,21.340094,4254.2988};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5478;
+									type="Land_RoadCone_01_F";
+								};
+								class Item137
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.529,21.30596,4255.1519};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5479;
+									type="Land_RoadCone_01_F";
+								};
+								class Item138
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.041,21.278894,4255.8286};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5480;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item139
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.835,21.26652,4256.1382};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5481;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item140
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11469.56,21.214748,4256.4829};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5482;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item141
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11470.328,21.158924,4256.8296};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5483;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item142
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11471.003,21.112072,4257.1064};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5484;
+									type="Land_RoadCone_01_F";
+								};
+								class Item143
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11471.739,21.065769,4257.3467};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5485;
+									type="Land_RoadCone_01_F";
+								};
+								class Item144
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11472.521,21.005169,4257.748};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5486;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item145
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11473.345,20.940973,4258.1768};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5487;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item146
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11474.231,20.88887,4258.4185};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5488;
+									type="Land_RoadCone_01_F";
+									atlOffset=3.8146973e-006;
+								};
+								class Item147
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11460.497,21.657267,4247.9233};
+										angles[]={0.069487326,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5489;
+									type="Land_RoadCone_01_F";
+								};
+								class Item148
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.229,21.646727,4248.0747};
+										angles[]={0.069487326,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5490;
+									type="Land_RoadCone_01_F";
+								};
+								class Item149
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.975,21.641045,4248.1563};
+										angles[]={0.069487326,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5491;
+									type="Land_RoadCone_01_F";
+								};
+								class Item150
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.627,21.639345,4248.1968};
+										angles[]={0.069488183,5.9190249,0.008802644};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5492;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.7166138e-005;
+								};
+								class Item151
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.289,21.642359,4248.2373};
+										angles[]={0.069488183,5.9190249,0.008802644};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5493;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.5258789e-005;
+								};
+								class Item152
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.978,21.647724,4248.2471};
+										angles[]={0.069488183,5.9190249,0.008802644};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5494;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.5258789e-005;
+								};
+								class Item153
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11464.672,21.646711,4248.2939};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5495;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-005;
+								};
+								class Item154
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.357,21.640669,4248.3711};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5496;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-005;
+								};
+								class Item155
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.018,21.64369,4248.3325};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5497;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-005;
+								};
+								class Item156
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.783,21.646999,4248.2905};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5498;
+									type="Land_RoadCone_01_F";
+								};
+								class Item157
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.591,21.597782,4248.918};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5499;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-005;
+								};
+								class Item158
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11472.986,21.39616,4252.481};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5500;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00028038025;
+								};
+								class Item159
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11473.723,21.349545,4252.7212};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5501;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0005645752;
+								};
+								class Item160
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11474.505,21.288975,4253.1226};
+										angles[]={0.077444658,5.9190249,6.2456045};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5502;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00058937073;
+								};
+								class Item161
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11475.328,21.244694,4253.5513};
+										angles[]={0.077444658,5.9190249,0.023197735};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5503;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00039672852;
+								};
+								class Item162
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11476.215,21.246525,4253.793};
+										angles[]={0.077444658,5.9190249,0.023197735};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5504;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00036621094;
+								};
+								class Item163
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11470.024,21.463617,4251.2031};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5505;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00030136108;
+								};
+								class Item164
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11470.818,21.451227,4251.5127};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5506;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00030136108;
+								};
+								class Item165
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11471.543,21.437449,4251.8574};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5507;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00030136108;
+								};
+								class Item166
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11472.312,21.423578,4252.2041};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5508;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00030136108;
+								};
+								class Item167
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11469.513,21.490683,4250.5264};
+										angles[]={0.039977662,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5509;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00030517578;
+								};
+								class Item168
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11469.145,21.538567,4249.6733};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5510;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-005;
+								};
+								class Item169
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.547,21.639523,4248.3857};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5511;
+									type="Land_RoadCone_01_F";
+								};
+								class Item170
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.188,21.633511,4248.4624};
+										angles[]={0.078239501,5.9190249,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5512;
+									type="Land_RoadCone_01_F";
+								};
+								class Item171
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11475.112,20.835007,4258.7715};
+										angles[]={0.077444658,5.9190249,0.023197735};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5513;
+									type="Land_RoadCone_01_F";
+								};
+								class Item172
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11477.096,21.239935,4254.146};
+										angles[]={0.077444658,5.9190249,0.023197735};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5514;
+									type="Land_RoadCone_01_F";
+								};
+								class Item173
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11476.023,21.038578,4256.4204};
+										angles[]={0.074969999,5.8265028,0.030265015};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5515;
+									type="Land_RoadCone_01_F";
+								};
+								class Item174
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.893,24.924768,4225.1685};
+										angles[]={0.11548408,1.1976644,6.2248516};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5318;
+									type="RoadCone_L_F";
+									atlOffset=-0.0010585785;
+								};
+								class Item175
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.468,22.695206,4234.4546};
+										angles[]={0.10204422,1.1976644,0.019996032};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5325;
+									type="RoadCone_L_F";
+								};
+								class Item176
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11477.697,22.448685,4238.7095};
+										angles[]={0.078239501,1.1976644,0.040777963};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5326;
+									type="RoadCone_L_F";
+								};
+								class Item177
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11489.448,22.557957,4243.001};
+										angles[]={0.09570726,1.1976644,0.072672337};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5327;
+									type="RoadCone_L_F";
+									atlOffset=-0.00045394897;
+								};
+								class Item178
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11509.837,23.278692,4247.3218};
+										angles[]={0.056738663,1.1976644,0.11153521};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5330;
+									type="RoadCone_L_F";
+								};
+								class Item179
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11510.248,23.204563,4249.437};
+										angles[]={0.056738663,1.1976644,0.11153521};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5331;
+									type="RoadCone_L_F";
+									atlOffset=-3.8146973e-005;
+								};
+								class Item180
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11512.371,23.081381,4257.7939};
+										angles[]={0.041577213,1.1976644,0.13909568};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5332;
+									type="RoadCone_L_F";
+									atlOffset=-0.0021934509;
+								};
+								class Item181
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11514.087,23.187134,4256.7266};
+										angles[]={0.041575778,1.1976644,0.027993103};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5338;
+									type="RoadCone_L_F";
+								};
+								class Item182
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11509.377,23.358341,4245.0122};
+										angles[]={0.056738663,1.1976644,0.11153521};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5348;
+									type="RoadCone_L_F";
+								};
+								class Item183
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11515.818,23.271158,4255.8726};
+										angles[]={0.041575778,1.1976644,0.027993103};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5349;
+									type="RoadCone_L_F";
+								};
+								class Item184
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11522.404,23.676426,4250.5635};
+										angles[]={0.041575778,1.1976644,0.027993103};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5350;
+									type="RoadCone_L_F";
+								};
+								class Item185
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11521.912,23.69783,4248.6313};
+										angles[]={0.0087958695,1.1976644,0.027990974};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5351;
+									type="RoadCone_L_F";
+								};
+								class Item186
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11521.132,23.692572,4246.7451};
+										angles[]={0.0087958695,1.1976644,0.027990974};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5352;
+									type="RoadCone_L_F";
+								};
+								class Item187
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.414,20.836208,4281.5596};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5519;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0012302399;
+								};
+								class Item188
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.208,20.791033,4281.8691};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5520;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0012283325;
+								};
+								class Item189
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.933,20.763611,4282.2139};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5521;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011920929;
+								};
+								class Item190
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.701,20.746662,4282.5605};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5522;
+									type="Land_RoadCone_01_F";
+									atlOffset=-8.2015991e-005;
+								};
+								class Item191
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11464.376,20.730892,4282.8374};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5523;
+									type="Land_RoadCone_01_F";
+									atlOffset=-8.0108643e-005;
+								};
+								class Item192
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.112,20.713823,4283.0776};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5524;
+									type="Land_RoadCone_01_F";
+									atlOffset=-8.2015991e-005;
+								};
+								class Item193
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.895,20.695343,4283.479};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5525;
+									type="Land_RoadCone_01_F";
+									atlOffset=-8.2015991e-005;
+								};
+								class Item194
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.718,20.662355,4283.9077};
+										angles[]={0.024795037,5.9190249,6.2384152};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5526;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.6702881e-005;
+								};
+								class Item195
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.604,20.616652,4284.1494};
+										angles[]={0.024795037,5.9190249,6.2384152};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5527;
+									type="Land_RoadCone_01_F";
+									atlOffset=-5.1498413e-005;
+								};
+								class Item196
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.359,20.696449,4278.2119};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5528;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011901855;
+								};
+								class Item197
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.096,20.679379,4278.4521};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5529;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011940002;
+								};
+								class Item198
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.878,20.6609,4278.8535};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5530;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011920929;
+								};
+								class Item199
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.701,20.641432,4279.2822};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5531;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011901855;
+								};
+								class Item200
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11469.588,20.620993,4279.5239};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5532;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011901855;
+								};
+								class Item201
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11463.397,20.765856,4276.9341};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5533;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0012111664;
+								};
+								class Item202
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11464.191,20.747341,4277.2437};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5534;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011901855;
+								};
+								class Item203
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11464.916,20.730278,4277.5884};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5535;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011920929;
+								};
+								class Item204
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11465.685,20.712236,4277.9351};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5536;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0011920929;
+								};
+								class Item205
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11468.485,20.568237,4284.5024};
+										angles[]={0.024795037,5.9190249,6.2384152};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5537;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00023841858;
+								};
+								class Item206
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11470.469,20.592785,4279.877};
+										angles[]={0.024795037,5.9190249,6.2384152};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5538;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0015296936;
+								};
+								class Item207
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11469.396,20.585354,4282.1514};
+										angles[]={0.024795037,5.8265028,6.2384152};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5539;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00057983398;
+								};
+								class Item208
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.897,20.781219,4275.667};
+										angles[]={0.0023920804,5.9190249,6.2607903};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5540;
+									type="Land_RoadCone_01_F";
+									atlOffset=-8.0108643e-005;
+								};
+								class Item209
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.536,20.800631,4274.436};
+										angles[]={0.017598685,5.9190249,6.2456031};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5541;
+									type="Land_RoadCone_01_F";
+								};
+								class Item210
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.291,20.828535,4273.52};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5542;
+									type="Land_RoadCone_01_F";
+								};
+								class Item211
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11462.035,20.858994,4272.498};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5543;
+									type="Land_RoadCone_01_F";
+								};
+								class Item212
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.746,20.893581,4271.3345};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5544;
+									type="Land_RoadCone_01_F";
+								};
+								class Item213
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.565,20.924715,4270.0669};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5545;
+									type="Land_RoadCone_01_F";
+								};
+								class Item214
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.457,20.949291,4268.9712};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5546;
+									type="Land_RoadCone_01_F";
+								};
+								class Item215
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11461.479,20.965889,4267.9668};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5547;
+									type="Land_RoadCone_01_F";
+									atlOffset=-3.6239624e-005;
+								};
+								class Item216
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11460.358,21.026907,4267.6074};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5548;
+									type="Land_RoadCone_01_F";
+								};
+								class Item217
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11458.686,21.117611,4267.0928};
+										angles[]={0.017598685,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5549;
+									type="Land_RoadCone_01_F";
+								};
+								class Item218
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11457.455,21.176529,4266.7437};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5550;
+									type="Land_RoadCone_01_F";
+								};
+								class Item219
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.47,21.217768,4266.5347};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5551;
+									type="Land_RoadCone_01_F";
+								};
+								class Item220
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11455.589,21.254799,4266.332};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5552;
+									type="Land_RoadCone_01_F";
+								};
+								class Item221
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11454.594,21.296803,4266.0811};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5553;
+									type="Land_RoadCone_01_F";
+								};
+								class Item222
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11453.798,21.331123,4265.7979};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5554;
+									type="Land_RoadCone_01_F";
+								};
+								class Item223
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11452.882,21.369999,4265.5449};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5555;
+									type="Land_RoadCone_01_F";
+								};
+								class Item224
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11451.979,21.408388,4265.2852};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5556;
+									type="Land_RoadCone_01_F";
+									atlOffset=-3.0517578e-005;
+								};
+								class Item225
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11450.656,21.464783,4264.8901};
+										angles[]={0.008802644,5.9190249,6.2432065};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5557;
+									type="Land_RoadCone_01_F";
+								};
+								class Item226
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11449.209,21.545753,4264.4126};
+										angles[]={0.0087958695,5.9190249,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5558;
+									type="Land_RoadCone_01_F";
+								};
+								class Item227
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11448.171,21.615147,4264.0981};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5559;
+									type="Land_RoadCone_01_F";
+								};
+								class Item228
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11447.519,21.651457,4264.686};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5560;
+									type="Land_RoadCone_01_F";
+								};
+								class Item229
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11446.495,21.710981,4265.4067};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5561;
+									type="Land_RoadCone_01_F";
+								};
+								class Item230
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.726,21.751266,4266.3013};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5562;
+									type="Land_RoadCone_01_F";
+								};
+								class Item231
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11444.863,21.797655,4267.2031};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5563;
+									type="Land_RoadCone_01_F";
+								};
+								class Item232
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.869,21.852045,4268.1729};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5564;
+									type="Land_RoadCone_01_F";
+								};
+								class Item233
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.358,21.880373,4268.6396};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5565;
+									type="Land_RoadCone_01_F";
+								};
+								class Item234
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11442.575,21.92944,4268.9199};
+										angles[]={0.012798273,5.9190249,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5566;
+									type="Land_RoadCone_01_F";
+								};
+								class Item235
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11453.075,21.267139,4278.1299};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5567;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.6702881e-005;
+								};
+								class Item236
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11453.869,21.229866,4278.4395};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5568;
+									type="Land_RoadCone_01_F";
+									atlOffset=-6.2942505e-005;
+								};
+								class Item237
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11454.594,21.196215,4278.7842};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5569;
+									type="Land_RoadCone_01_F";
+								};
+								class Item238
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11455.362,21.160387,4279.1309};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5570;
+									type="Land_RoadCone_01_F";
+								};
+								class Item239
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.037,21.128765,4279.4077};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5571;
+									type="Land_RoadCone_01_F";
+								};
+								class Item240
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11456.773,21.093988,4279.6479};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5572;
+									type="Land_RoadCone_01_F";
+								};
+								class Item241
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11457.556,21.057138,4280.0493};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5573;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.4795532e-005;
+								};
+								class Item242
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11458.379,21.010008,4280.478};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5574;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.4795532e-005;
+								};
+								class Item243
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11459.266,20.959784,4280.7197};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5575;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.7166138e-005;
+								};
+								class Item244
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11460.146,20.909588,4281.0728};
+										angles[]={0.0023920804,5.9190249,6.2272449};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5576;
+									type="Land_RoadCone_01_F";
+									atlOffset=-2.4795532e-005;
+								};
+								class Item245
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11444.52,21.748959,4274.9971};
+										angles[]={0.0050565908,5.9781017,6.2196636};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5577;
+									type="Land_RoadCone_01_F";
+								};
+								class Item246
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11445.33,21.699242,4275.2593};
+										angles[]={6.2778478,5.9781027,6.2202768};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5578;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.001115799;
+								};
+								class Item247
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11446.074,21.653984,4275.561};
+										angles[]={6.2778478,5.9781027,6.2202768};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5579;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0024356842;
+								};
+								class Item248
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11446.859,21.605936,4275.8618};
+										angles[]={6.2778478,5.9781027,6.2202768};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5580;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0035247803;
+								};
+								class Item249
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11447.552,21.563776,4276.0972};
+										angles[]={6.2778478,5.9781027,6.2202768};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5581;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0047206879;
+								};
+								class Item250
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11448.301,21.51763,4276.2939};
+										angles[]={6.2778478,5.9781027,6.2202768};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5582;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0056095123;
+								};
+								class Item251
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11449.105,21.471699,4276.6494};
+										angles[]={6.2748637,5.9780898,6.2236476};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5583;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0076541901;
+								};
+								class Item252
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11450.242,21.400906,4277.1997};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5584;
+									type="Land_RoadCone_01_F";
+									atlOffset=-7.0571899e-005;
+								};
+								class Item253
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11451.129,21.358805,4277.4414};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5585;
+									type="Land_RoadCone_01_F";
+									atlOffset=-7.0571899e-005;
+								};
+								class Item254
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11452.01,21.317503,4277.7944};
+										angles[]={6.278389,5.9190249,6.2344246};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5586;
+									type="Land_RoadCone_01_F";
+									atlOffset=-6.2942505e-005;
+								};
+								class Item255
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11438.577,22.1465,4272.9214};
+										angles[]={0.012798273,5.9946704,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5587;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00037002563;
+								};
+								class Item256
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.391,22.08935,4273.1694};
+										angles[]={0.0087958695,5.9946704,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5588;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00013923645;
+								};
+								class Item257
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.143,22.040451,4273.4604};
+										angles[]={0.0087958695,5.9946704,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5589;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0013446808;
+								};
+								class Item258
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.934,21.988998,4273.7476};
+										angles[]={0.0087958695,5.9946504,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5590;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0024223328;
+								};
+								class Item259
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11441.628,21.943935,4273.9717};
+										angles[]={0.0087958695,5.9946504,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5591;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0032062531;
+								};
+								class Item260
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11442.38,21.895243,4274.1563};
+										angles[]={0.0087958695,5.9946504,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5592;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0036334991;
+								};
+								class Item261
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11443.189,21.84235,4274.4976};
+										angles[]={0.0087958695,5.9946504,6.2200694};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5593;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0049037933;
+								};
+								class Item262
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11432.79,22.357513,4270.8901};
+										angles[]={0.012999518,5.9862704,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5594;
+									type="Land_RoadCone_01_F";
+								};
+								class Item263
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11433.604,22.334803,4271.144};
+										angles[]={0.012999518,5.9862704,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5595;
+									type="Land_RoadCone_01_F";
+									atlOffset=7.8201294e-005;
+								};
+								class Item264
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11434.352,22.313042,4271.4424};
+										angles[]={0.012999518,5.9862704,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5596;
+									type="Land_RoadCone_01_F";
+									atlOffset=8.0108643e-005;
+								};
+								class Item265
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.141,22.290377,4271.7368};
+										angles[]={0.012999518,5.9862504,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5597;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00011062622;
+								};
+								class Item266
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.831,22.270849,4271.9658};
+										angles[]={0.012999518,5.9862504,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5598;
+									type="Land_RoadCone_01_F";
+									atlOffset=8.9645386e-005;
+								};
+								class Item267
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11436.583,22.250431,4272.1572};
+										angles[]={0.012999518,5.9862504,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5599;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00017738342;
+								};
+								class Item268
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11437.39,22.227844,4272.5059};
+										angles[]={0.012999518,5.9862504,6.2593026};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5600;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0014019012;
+								};
+								class Item269
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11438.456,22.224833,4267.4678};
+										angles[]={0.012798273,5.9946704,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5601;
+									type="Land_RoadCone_01_F";
+								};
+								class Item270
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11439.27,22.167498,4267.7158};
+										angles[]={0.012798273,5.9946704,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5602;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00049781799;
+								};
+								class Item271
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.021,22.114426,4268.0068};
+										angles[]={0.012798273,5.9946704,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5603;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0017032623;
+								};
+								class Item272
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.813,22.058313,4268.2939};
+										angles[]={0.012798273,5.9946504,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5604;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0024795532;
+								};
+								class Item273
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11441.507,22.009575,4268.5181};
+										angles[]={0.012798273,5.9946504,6.2160869};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5605;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0032176971;
+								};
+								class Item274
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11434.23,22.385763,4265.9888};
+										angles[]={0.012798273,5.9862704,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5608;
+									type="Land_RoadCone_01_F";
+									atlOffset=8.0108643e-005;
+								};
+								class Item275
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.02,22.363071,4266.2832};
+										angles[]={0.012798273,5.9862504,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5609;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00011062622;
+								};
+								class Item276
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11435.71,22.34355,4266.5122};
+										angles[]={0.012798273,5.9862504,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5610;
+									type="Land_RoadCone_01_F";
+									atlOffset=8.9645386e-005;
+								};
+								class Item277
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11436.462,22.323151,4266.7036};
+										angles[]={0.012798273,5.9862504,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5611;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00017738342;
+								};
+								class Item278
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11437.269,22.300171,4267.0522};
+										angles[]={0.012798273,5.9862504,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5612;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0010318756;
+								};
+								class Item279
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.656,22.415033,4270.396};
+										angles[]={0.012798273,5.9946704,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5613;
+									type="Land_RoadCone_01_F";
+								};
+								class Item280
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11431.47,22.392836,4270.644};
+										angles[]={0.012798273,5.9946704,6.259192};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5614;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00049591064;
+								};
+								class Item281
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.869,22.574963,4268.3647};
+										angles[]={0.013602046,5.9862704,0.048762105};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5615;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.001127243;
+								};
+								class Item282
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.683,22.561789,4268.6187};
+										angles[]={0.013597663,5.9862704,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5616;
+									type="Land_RoadCone_01_F";
+									atlOffset=7.6293945e-005;
+								};
+								class Item283
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11426.431,22.53919,4268.917};
+										angles[]={0.013597663,5.9862704,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5617;
+									type="Land_RoadCone_01_F";
+									atlOffset=7.8201294e-005;
+								};
+								class Item284
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11427.22,22.515652,4269.2114};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5618;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00010871887;
+								};
+								class Item285
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11427.91,22.495401,4269.4404};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5619;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00010108948;
+								};
+								class Item286
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.662,22.474236,4269.6318};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5620;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00018882751;
+								};
+								class Item287
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11429.469,22.45072,4269.9805};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5621;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0014133453;
+								};
+								class Item288
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11430.202,22.504522,4264.5835};
+										angles[]={0.013597663,5.9946704,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5622;
+									type="Land_RoadCone_01_F";
+								};
+								class Item289
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11431.016,22.481451,4264.8315};
+										angles[]={0.013597663,5.9946704,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5623;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00049591064;
+								};
+								class Item290
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11431.768,22.460075,4265.1226};
+										angles[]={0.013597663,5.9946704,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5624;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0017147064;
+								};
+								class Item291
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11432.559,22.437279,4265.4097};
+										angles[]={0.013597663,5.9946504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5625;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0024394989;
+								};
+								class Item292
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11433.253,22.417799,4265.6338};
+										angles[]={0.013597663,5.9946504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5626;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0032291412;
+								};
+								class Item293
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11426.766,22.605959,4263.3989};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5628;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00010871887;
+								};
+								class Item294
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11427.456,22.585703,4263.6279};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5629;
+									type="Land_RoadCone_01_F";
+									atlOffset=8.7738037e-005;
+								};
+								class Item295
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11428.208,22.564528,4263.8193};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5630;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.00017547607;
+								};
+								class Item296
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11429.015,22.541012,4264.168};
+										angles[]={0.013597663,5.9862504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5631;
+									type="Land_RoadCone_01_F";
+									atlOffset=0.0013999939;
+								};
+								class Item297
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.152,22.456429,4267.415};
+										angles[]={0.013602046,5.9946704,0.048762105};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5651;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item298
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.966,22.492744,4267.6631};
+										angles[]={0.013602046,5.9946704,0.048762105};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5652;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item299
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.718,22.525496,4267.9541};
+										angles[]={0.013602046,5.9946704,0.048762105};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5653;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item300
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11416.365,22.58901,4265.3838};
+										angles[]={0.080624484,5.9862704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5654;
+									type="Land_RoadCone_01_F";
+								};
+								class Item301
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.179,22.553518,4265.6377};
+										angles[]={0.080624484,5.9862704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5655;
+									type="Land_RoadCone_01_F";
+								};
+								class Item302
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.927,22.515657,4265.936};
+										angles[]={0.080624484,5.9862704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5656;
+									type="Land_RoadCone_01_F";
+								};
+								class Item303
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11418.716,22.475443,4266.2305};
+										angles[]={0.080624484,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5657;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0018901825;
+								};
+								class Item304
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11419.406,22.444246,4266.4595};
+										angles[]={0.080624484,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5658;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0018882751;
+								};
+								class Item305
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.158,22.414944,4266.6509};
+										angles[]={0.080624484,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5659;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0018901825;
+								};
+								class Item306
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.965,22.404146,4266.9995};
+										angles[]={0.013602046,5.9862504,0.048762105};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5660;
+									type="Land_RoadCone_01_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item307
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.031,22.730627,4261.9614};
+										angles[]={0.027193764,5.9946704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5661;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00059127808;
+								};
+								class Item308
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11422.845,22.708504,4262.2095};
+										angles[]={0.027193764,5.9946704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5662;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00099563599;
+								};
+								class Item309
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.597,22.686762,4262.5005};
+										angles[]={0.027193764,5.9946704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5663;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00039672852;
+								};
+								class Item310
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.388,22.650185,4262.7876};
+										angles[]={0.080624484,5.9946504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5664;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00096511841;
+								};
+								class Item311
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.082,22.652876,4263.0117};
+										angles[]={0.013597663,5.9946504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5665;
+									type="Land_RoadCone_01_F";
+								};
+								class Item312
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.806,22.849188,4260.4824};
+										angles[]={0.027193764,5.9862704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5666;
+									type="Land_RoadCone_01_F";
+								};
+								class Item313
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11418.595,22.826664,4260.7769};
+										angles[]={0.027193764,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5667;
+									type="Land_RoadCone_01_F";
+								};
+								class Item314
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11419.285,22.807722,4261.0059};
+										angles[]={0.027193764,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5668;
+									type="Land_RoadCone_01_F";
+								};
+								class Item315
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.037,22.788105,4261.1973};
+										angles[]={0.027193764,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5669;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00059318542;
+								};
+								class Item316
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11420.844,22.763769,4261.5459};
+										angles[]={0.027193764,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5670;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00059318542;
+								};
+								class Item317
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11414.231,22.668192,4264.8896};
+										angles[]={0.080624484,5.9946704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5671;
+									type="Land_RoadCone_01_F";
+								};
+								class Item318
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.045,22.633192,4265.1377};
+										angles[]={0.080624484,5.9946704,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5672;
+									type="Land_RoadCone_01_F";
+								};
+								class Item319
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11408.444,22.661123,4262.8584};
+										angles[]={0.058332846,5.9862704,0.051952176};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5673;
+									type="Land_RoadCone_01_F";
+								};
+								class Item320
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11409.258,22.688597,4263.1123};
+										angles[]={0.058332846,5.9862704,0.051952176};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5674;
+									type="Land_RoadCone_01_F";
+								};
+								class Item321
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11410.006,22.709852,4263.4106};
+										angles[]={0.058332846,5.9862704,0.051952176};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5675;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00024414063;
+								};
+								class Item322
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11410.795,22.733675,4263.7051};
+										angles[]={0.058332846,5.9862504,0.051952176};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5676;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00024414063;
+								};
+								class Item323
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11411.485,22.746853,4263.9341};
+										angles[]={0.080624484,5.9862504,0.029591488};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5677;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00045394897;
+								};
+								class Item324
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11412.237,22.753626,4264.1255};
+										angles[]={0.080624484,5.9862504,0.029591488};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5678;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00047683716;
+								};
+								class Item325
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11413.044,22.723614,4264.4741};
+										angles[]={0.080624484,5.9862504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5679;
+									type="Land_RoadCone_01_F";
+								};
+								class Item326
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11413.777,23.051567,4259.0771};
+										angles[]={0.068692133,5.9946704,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5680;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00070571899;
+								};
+								class Item327
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11414.591,22.98571,4259.3252};
+										angles[]={0.068692133,5.9946704,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5681;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00070571899;
+								};
+								class Item328
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.343,22.920549,4259.6162};
+										angles[]={0.068692133,5.9946704,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5682;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.00070571899;
+								};
+								class Item329
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11416.134,22.89571,4259.9033};
+										angles[]={0.027193764,5.9946504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5683;
+									type="Land_RoadCone_01_F";
+								};
+								class Item330
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11416.828,22.876837,4260.1274};
+										angles[]={0.027193764,5.9946504,6.2647886};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5684;
+									type="Land_RoadCone_01_F";
+								};
+								class Item331
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11410.341,23.097969,4257.8926};
+										angles[]={0.068691261,5.9862504,0.051953323};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5685;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item332
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11411.031,23.118101,4258.1216};
+										angles[]={0.068691261,5.9862504,0.051953323};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5686;
+									type="Land_RoadCone_01_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item333
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11411.783,23.141441,4258.313};
+										angles[]={0.068691261,5.9862504,0.051953323};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5687;
+									type="Land_RoadCone_01_F";
+									atlOffset=-0.0025634766;
+								};
+								class Item334
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11412.59,23.152153,4258.6616};
+										angles[]={0.068692133,5.9862504,6.2232571};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5688;
+									type="Land_RoadCone_01_F";
+								};
+								class Item335
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11425.924,22.627836,4263.3169};
+										angles[]={0.013597663,5.9946504,6.2583928};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										disableSimulation=1;
+									};
+									id=5689;
+									type="Land_RoadCone_01_F";
+								};
+							};
+							id=5518;
+							atlOffset=0.064100266;
+						};
+						class Item1
+						{
+							dataType="Layer";
+							name="Fence";
+							class Entities
+							{
+								items=37;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11530.345,21.808395,4311.7729};
+										angles[]={0,4.3094897,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5701;
+									type="Land_IndFnc_3_F";
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11529.264,21.921385,4314.5068};
+										angles[]={0,4.3094897,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5731;
+									type="Land_IndFnc_3_F";
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11552.071,21.843929,4255.9746};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=5693;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.25971413;
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11548.777,21.661819,4264.3828};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=5694;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.25989342;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11542.234,21.580721,4281.1187};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=5695;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.26013184;
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11545.528,21.552366,4272.7104};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=1;
+									class Attributes
+									{
+									};
+									id=5696;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.25995064;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11532.404,21.711138,4306.1787};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5697;
+									type="Land_IndFnc_9_F";
+									atlOffset=6.1035156e-005;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11535.653,21.561407,4297.8511};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5699;
+									type="Land_IndFnc_9_F";
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11538.947,21.521935,4289.4429};
+										angles[]={0,4.3369169,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5700;
+									type="Land_IndFnc_9_F";
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11499.987,25.531963,4228.4941};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5703;
+									type="Land_IndFnc_9_F";
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11508.266,24.998775,4232.0986};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5704;
+									type="Land_IndFnc_9_F";
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11524.746,24.207354,4239.2651};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5705;
+									type="Land_IndFnc_9_F";
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11516.467,24.546627,4235.6572};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5706;
+									type="Land_IndFnc_9_F";
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11549.423,22.169077,4250.0229};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5707;
+									type="Land_IndFnc_9_F";
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11541.221,23.29377,4246.4697};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5708;
+									type="Land_IndFnc_9_F";
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11532.941,23.746832,4242.8608};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5709;
+									type="Land_IndFnc_9_F";
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11442.403,27.241188,4203.2124};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5710;
+									type="Land_IndFnc_9_F";
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11450.682,26.435221,4206.8169};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5711;
+									type="Land_IndFnc_9_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11467.162,25.568325,4213.9834};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5712;
+									type="Land_IndFnc_9_F";
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11458.883,25.911354,4210.3755};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5713;
+									type="Land_IndFnc_9_F";
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11491.839,25.449747,4224.7412};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5714;
+									type="Land_IndFnc_9_F";
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11483.637,25.406546,4221.188};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5715;
+									type="Land_IndFnc_9_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11475.357,25.405437,4217.5791};
+										angles[]={0,5.8703003,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5716;
+									type="Land_IndFnc_9_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item23
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11466.102,21.195169,4291.1841};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5717;
+									type="Land_IndFnc_9_F";
+								};
+								class Item24
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11457.697,21.360991,4287.8921};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5718;
+									type="Land_IndFnc_9_F";
+								};
+								class Item25
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11440.959,22.400654,4281.3462};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5719;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.12907028;
+								};
+								class Item26
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11449.372,21.773966,4284.6436};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5720;
+									type="Land_IndFnc_9_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item27
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.899,22.398531,4271.519};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5721;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.0098133087;
+								};
+								class Item28
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.225,22.745308,4274.7671};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5722;
+									type="Land_IndFnc_9_F";
+									atlOffset=1.9073486e-006;
+								};
+								class Item29
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11432.634,22.741325,4278.0601};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5723;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.21796608;
+								};
+								class Item30
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11524.596,21.77433,4314.2915};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5724;
+									type="Land_IndFnc_9_F";
+								};
+								class Item31
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11516.187,21.314388,4310.998};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5725;
+									type="Land_IndFnc_9_F";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item32
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11499.448,21.535023,4304.4556};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5726;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.011543274;
+								};
+								class Item33
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11507.855,21.47575,4307.7529};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5727;
+									type="Land_IndFnc_9_F";
+									atlOffset=0.0011005402;
+								};
+								class Item34
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11474.388,20.703974,4294.6299};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5728;
+									type="Land_IndFnc_9_F";
+								};
+								class Item35
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11482.716,20.504494,4297.8745};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5729;
+									type="Land_IndFnc_9_F";
+								};
+								class Item36
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11491.122,20.837357,4301.1714};
+										angles[]={0,2.7661557,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5730;
+									type="Land_IndFnc_9_F";
+								};
+							};
+							id=5732;
+							atlOffset=0.2718029;
+						};
+						class Item2
+						{
+							dataType="Layer";
+							name="Obstacles";
+							class Entities
+							{
+								items=23;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11504.862,21.97427,4293.0635};
+										angles[]={6.2296386,2.807013,0.051155601};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										lock="LOCKED";
+										name="hiluxBlockVic1";
+									};
+									id=5690;
+									type="CUP_I_Hilux_unarmed_IND_G_F";
+									atlOffset=-0.034000397;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="ammoBox";
+											expression="[_this,_value] call bis_fnc_initAmmoBox;";
+											class Value
+											{
+												class data
+												{
+													singleType="STRING";
+													value="[[[[""FirstAidKit"",""Medikit""],[10,1]],[[],[]],[[""ToolKit""],[1]],[[],[]]],false]";
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11506.703,21.790083,4287.8687};
+										angles[]={6.2296386,5.8614092,0.051155601};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										lock="LOCKED";
+										name="hiluxBlockVic2";
+									};
+									id=5691;
+									type="CUP_I_Hilux_unarmed_IND_G_F";
+									atlOffset=-0.034000397;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="ammoBox";
+											expression="[_this,_value] call bis_fnc_initAmmoBox;";
+											class Value
+											{
+												class data
+												{
+													singleType="STRING";
+													value="[[[[""FirstAidKit"",""Medikit""],[10,1]],[[],[]],[[""ToolKit""],[1]],[[],[]]],false]";
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11506.132,20.322512,4290.4585};
+										angles[]={6.2296371,1.3193049,0.051155224};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5739;
+									type="CUP_A1_Road_asf25";
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11518.863,22.167011,4274.9741};
+										angles[]={0.055941612,6.0423093,0.057536088};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5755;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11517.422,22.107325,4274.5576};
+										angles[]={0.055941612,6.0423093,0.057536088};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5756;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11516.106,22.057266,4274.0972};
+										angles[]={0.055941612,6.0423093,0.057536088};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5757;
+									type="Obstacle_saddle";
+									atlOffset=-4.0054321e-005;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11514.461,21.99379,4273.5396};
+										angles[]={0.055941612,6.0423093,0.057536088};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5758;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11513.176,21.959116,4273.0693};
+										angles[]={0.066302508,6.0423093,0.047165871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5759;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11512.143,21.897215,4272.7544};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5760;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11511.041,21.764551,4272.3896};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5761;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11510.12,21.658293,4272.0151};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5762;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11509.278,21.552948,4271.7969};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5763;
+									type="Obstacle_saddle";
+									atlOffset=4.0054321e-005;
+								};
+								class Item12
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11508.334,21.517578,4271.4448};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5765;
+									type="Obstacle_saddle";
+									atlOffset=0.075788498;
+								};
+								class Item13
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11506.893,21.342516,4271.0283};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5766;
+									type="Obstacle_saddle";
+									atlOffset=0.078294754;
+								};
+								class Item14
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11505.577,21.107492,4270.5679};
+										angles[]={0.066302508,6.0423093,0.14144896};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5767;
+									type="Obstacle_saddle";
+									atlOffset=-1.9073486e-006;
+								};
+								class Item15
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11503.932,20.912783,4270.0103};
+										angles[]={0.068691261,6.0423093,0.13909611};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5768;
+									type="Obstacle_saddle";
+									atlOffset=5.7220459e-005;
+								};
+								class Item16
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11502.646,20.765141,4269.54};
+										angles[]={0.068691261,6.0423093,0.13909611};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5769;
+									type="Obstacle_saddle";
+									atlOffset=5.7220459e-005;
+								};
+								class Item17
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11501.613,20.642193,4269.2251};
+										angles[]={0.068691261,6.0423093,0.13909611};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5770;
+									type="Obstacle_saddle";
+									atlOffset=5.531311e-005;
+								};
+								class Item18
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11500.512,20.513048,4268.8604};
+										angles[]={0.068691261,6.0423093,0.13909611};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5771;
+									type="Obstacle_saddle";
+									atlOffset=5.531311e-005;
+								};
+								class Item19
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11499.591,20.449556,4268.4858};
+										angles[]={0.068692133,6.0423093,0.043174155};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5772;
+									type="Obstacle_saddle";
+									atlOffset=5.3405762e-005;
+								};
+								class Item20
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11498.749,20.428215,4268.2676};
+										angles[]={0.068692133,6.0423093,0.043174155};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5773;
+									type="Obstacle_saddle";
+									atlOffset=5.3405762e-005;
+								};
+								class Item21
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11503.52,20.128191,4288.1948};
+										angles[]={6.2296386,5.8614092,0.051155601};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										name="vic2DirSetter";
+									};
+									id=5795;
+									type="IDAP_Mug_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="hideObject";
+											expression="if !(is3DEN) then {_this hideobjectglobal _value;};";
+											class Value
+											{
+												class data
+												{
+													singleType="BOOL";
+													value=1;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+								class Item22
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11502.365,20.255728,4291.6768};
+										angles[]={6.2296386,2.807013,0.051155601};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										name="vic1DirSetter";
+									};
+									id=5794;
+									type="IDAP_Mug_F";
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="hideObject";
+											expression="if !(is3DEN) then {_this hideobjectglobal _value;};";
+											class Value
+											{
+												class data
+												{
+													singleType="BOOL";
+													value=1;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+							};
+							id=5788;
+							atlOffset=0.066524506;
+						};
+						class Item3
+						{
+							dataType="Layer";
+							name="Parking";
+							class Entities
+							{
+								items=12;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11385.729,21.185841,4270.6475};
+										angles[]={0.072301395,2.72735,0.041415013};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5777;
+									type="Land_ConcreteKerb_03_BW_long_F";
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11390.891,21.315857,4272.9849};
+										angles[]={0.058986798,2.7274075,0.005617497};
+									};
+									side="Empty";
+									class Attributes
+									{
+									};
+									id=5778;
+									type="Land_ConcreteKerb_03_BW_long_F";
+									atlOffset=0.19290352;
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11375.359,21.467403,4265.9536};
+										angles[]={0.10932165,2.7146726,6.2806797};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5779;
+									type="Land_ConcreteKerb_03_BW_long_F";
+									atlOffset=0.093601227;
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11380.537,21.277655,4268.3101};
+										angles[]={0.10932165,2.7089691,6.2806797};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5780;
+									type="Land_ConcreteKerb_03_BW_long_F";
+									atlOffset=0.12897301;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11374.104,21.94046,4262.1396};
+										angles[]={0.13041492,4.2637758,6.1900678};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5781;
+									type="Land_ConcreteKerb_03_BY_long_F";
+									atlOffset=0.066762924;
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11379.21,21.618538,4264.4868};
+										angles[]={0.10932165,4.258008,6.2806797};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5782;
+									type="Land_ConcreteKerb_03_BY_long_F";
+									atlOffset=0.059335709;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11384.368,21.543724,4266.793};
+										angles[]={0.072301395,4.2646799,0.041415013};
+									};
+									side="Empty";
+									class Attributes
+									{
+									};
+									id=5783;
+									type="Land_ConcreteKerb_03_BY_long_F";
+									atlOffset=0.15690994;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11389.576,21.444437,4269.1548};
+										angles[]={0.068463393,4.276391,6.2775922};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5784;
+									type="Land_ConcreteKerb_03_BY_long_F";
+									atlOffset=0.072282791;
+								};
+								class Item8
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11394.629,21.353685,4271.4453};
+										angles[]={0.058986798,4.2583189,0.005617497};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5785;
+									type="Land_ConcreteKerb_03_BY_long_F";
+									atlOffset=0.10193825;
+								};
+								class Item9
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11392.481,21.470751,4269.1367};
+										angles[]={0.068691261,5.8470216,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5316;
+									type="synixe_contractors_Arcadian_I_Black";
+									atlOffset=0.0090789795;
+								};
+								class Item10
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11387.343,23.044506,4268.1597};
+										angles[]={0.068692133,5.8676305,0.047165871};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5786;
+									type="CUP_I_Hilux_unarmed_IND_G_F";
+									atlOffset=-0.0010490417;
+								};
+								class Item11
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11382.047,23.048279,4265.4731};
+										angles[]={0.10916402,5.8874531,0.006394445};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5787;
+									type="I_MU_mercs_Jeep";
+									atlOffset=2.2888184e-005;
+								};
+							};
+							id=5789;
+							atlOffset=0.020589828;
+						};
+						class Item4
+						{
+							dataType="Layer";
+							name="Platform";
+							class Entities
+							{
+								items=8;
+								class Item0
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.014,25.780403,4197.5288};
+										angles[]={0,3.796946,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5744;
+									type="CargoPlaftorm_01_green_F";
+									atlOffset=-5.9019184;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="Leg_4_move";
+											expression="_this animateSource ['Leg_4_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.89529419;
+												};
+											};
+										};
+										class Attribute1
+										{
+											property="Leg_3_move";
+											expression="_this animateSource ['Leg_3_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.92394787;
+												};
+											};
+										};
+										class Attribute2
+										{
+											property="Leg_2_move";
+											expression="_this animateSource ['Leg_2_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.9082588;
+												};
+											};
+										};
+										class Attribute3
+										{
+											property="Leg_1_move";
+											expression="_this animateSource ['Leg_1_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.90602446;
+												};
+											};
+										};
+										class Attribute4
+										{
+											property="Panel_2_hide";
+											expression="_this animateSource ['Panel_2_hide_source',_value,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=1;
+												};
+											};
+										};
+										class Attribute5
+										{
+											property="Panel_1_hide";
+											expression="_this animateSource ['Panel_1_hide_source',_value,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=1;
+												};
+											};
+										};
+										nAttributes=6;
+									};
+								};
+								class Item1
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11421.783,25.780403,4193.8623};
+										angles[]={0,3.7969458,0};
+									};
+									side="Empty";
+									flags=5;
+									class Attributes
+									{
+									};
+									id=5743;
+									type="CargoPlaftorm_01_green_F";
+									atlOffset=-6.002327;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="Leg_4_move";
+											expression="_this animateSource ['Leg_4_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.92597038;
+												};
+											};
+										};
+										class Attribute1
+										{
+											property="Leg_3_move";
+											expression="_this animateSource ['Leg_3_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.93412614;
+												};
+											};
+										};
+										class Attribute2
+										{
+											property="Panel_4_hide";
+											expression="_this animateSource ['Panel_4_hide_source',_value,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=1;
+												};
+											};
+										};
+										class Attribute3
+										{
+											property="Leg_2_move";
+											expression="_this animateSource ['Leg_2_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.91092658;
+												};
+											};
+										};
+										class Attribute4
+										{
+											property="Leg_1_move";
+											expression="_this animateSource ['Leg_1_move_source',_value*6.541,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=0.90869534;
+												};
+											};
+										};
+										class Attribute5
+										{
+											property="Panel_1_hide";
+											expression="_this animateSource ['Panel_1_hide_source',_value,true]";
+											class Value
+											{
+												class data
+												{
+													singleType="SCALAR";
+													value=1;
+												};
+											};
+										};
+										nAttributes=6;
+									};
+								};
+								class Item2
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11411.341,26.196205,4191.645};
+										angles[]={0.020154923,0.67972064,6.2655196};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5746;
+									type="Land_Platform_Stairs_20";
+									atlOffset=-2.4298229;
+								};
+								class Item3
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11417.431,26.36405,4187.1143};
+										angles[]={0.05498914,0.67647445,6.2426596};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5745;
+									type="Land_Platform_Stairs_20";
+									atlOffset=-2.2810631;
+								};
+								class Item4
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11424.031,30.448599,4193.417};
+										angles[]={0.884498,0.6768561,4.7604208};
+									};
+									side="Empty";
+									class Attributes
+									{
+										name="drivingFAK";
+									};
+									id=5516;
+									type="Land_FirstAidKit_01_closed_F";
+									atlOffset=0.737463;
+								};
+								class Item5
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.923,29.943527,4193.9219};
+										angles[]={0,1.3742278,0};
+									};
+									side="Empty";
+									class Attributes
+									{
+									};
+									id=5747;
+									type="Land_CampingTable_F";
+									atlOffset=1.1017361;
+								};
+								class Item6
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11423.735,30.504097,4194.4868};
+										angles[]={0,4.1943579,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+										name="drivingLap";
+									};
+									id=5749;
+									type="Land_Laptop_unfolded_F";
+									atlOffset=0.00045204163;
+								};
+								class Item7
+								{
+									dataType="Object";
+									class PositionInfo
+									{
+										position[]={11415.506,30.169674,4198.2813};
+										angles[]={0,0.72157145,0};
+									};
+									side="Empty";
+									flags=4;
+									class Attributes
+									{
+									};
+									id=5750;
+									type="CargoNet_01_box_F";
+									atlOffset=0.0023784637;
+									class CustomAttributes
+									{
+										class Attribute0
+										{
+											property="crate_client_gear_attribute_shop";
+											expression="if(_value)then{crate_client_gear_shop_boxes pushBack _this}";
+											class Value
+											{
+												class data
+												{
+													singleType="BOOL";
+													value=1;
+												};
+											};
+										};
+										nAttributes=1;
+									};
+								};
+							};
+							id=5790;
+							atlOffset=1.2178268;
+						};
+						class Item5
+						{
+							dataType="Logic";
+							class PositionInfo
+							{
+								position[]={11475.42,20.665905,4257.8237};
+								angles[]={0,1.1971304,0};
+							};
+							areaSize[]={37.048561,0,83.011803};
+							areaIsRectangle=1;
+							flags=1;
+							id=4553;
+							type="ModuleHideTerrainObjects_F";
+							atlOffset=0.16327858;
+							class CustomAttributes
+							{
+								class Attribute0
+								{
+									property="#filter";
+									expression="_this setVariable [""#filter"",_value]";
+									class Value
+									{
+										class data
+										{
+											singleType="SCALAR";
+											value=15;
+										};
+									};
+								};
+								class Attribute1
+								{
+									property="#hideLocally";
+									expression="_this setVariable [""#hideLocally"",_value]";
+									class Value
+									{
+										class data
+										{
+											singleType="BOOL";
+											value=0;
+										};
+									};
+								};
+								nAttributes=2;
+							};
+						};
+						class Item6
+						{
+							dataType="Marker";
+							position[]={11441.394,21.538,4249.6538};
+							name="marker_22";
+							text="Driving Course";
+							type="mil_box";
+							id=5791;
+							atlOffset=0.00036621094;
+						};
+					};
+					id=5517;
+					atlOffset=0.73586845;
+				};
 			};
 			id=3565;
-			atlOffset=-0.19898033;
+			atlOffset=13.881173;
 		};
 		class Item3
 		{
@@ -49847,7 +57612,6 @@ class Mission
 							};
 							id=3717;
 							type="CUP_C_Merlin_HC3_CIV_Lux";
-							atlOffset=-0.033752441;
 							class CustomAttributes
 							{
 								class Attribute0
@@ -50586,104 +58350,21 @@ class Mission
 		};
 		class Item4
 		{
-			dataType="Object";
-			class PositionInfo
-			{
-				position[]={9770.3066,39.87553,3867.9839};
-				angles[]={0,4.7128949,0};
-			};
-			side="Empty";
-			flags=4;
-			class Attributes
-			{
-			};
-			id=4538;
-			type="Box_NATO_Equip_F";
-			atlOffset=8.7738037e-005;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_arsenal_attribute";
-					expression="if (!is3DEN) then {[_this, +_value] call ace_arsenal_fnc_attributeInit}";
-					class Value
-					{
-						class data
-						{
-							singleType="ARRAY";
-							class value
-							{
-								items=2;
-								class Item0
-								{
-									class data
-									{
-										singleType="ARRAY";
-										class value
-										{
-											items=4;
-											class Item0
-											{
-												class data
-												{
-													singleType="STRING";
-													value="ACE_microDAGR";
-												};
-											};
-											class Item1
-											{
-												class data
-												{
-													singleType="STRING";
-													value="ACE_DAGR";
-												};
-											};
-											class Item2
-											{
-												class data
-												{
-													singleType="STRING";
-													value="ACE_Vector";
-												};
-											};
-											class Item3
-											{
-												class data
-												{
-													singleType="STRING";
-													value="ACE_VectorDay";
-												};
-											};
-										};
-									};
-								};
-								class Item1
-								{
-									class data
-									{
-										singleType="SCALAR";
-										value=0;
-									};
-								};
-							};
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ammoBox";
-					expression="[_this,_value] call bis_fnc_initAmmoBox;";
-					class Value
-					{
-						class data
-						{
-							singleType="STRING";
-							value="[[[[],[]],[[],[]],[[],[]],[[],[]]],false]";
-						};
-					};
-				};
-				nAttributes=2;
-			};
+			dataType="Marker";
+			position[]={11506.761,20.214001,4287.8428};
+			name="hiluxBarricade2";
+			type="Empty";
+			id=5792;
+			atlOffset=-0.0004940033;
+		};
+		class Item5
+		{
+			dataType="Marker";
+			position[]={11504.946,20.402,4293.0708};
+			name="hiluxBarricade1";
+			type="Empty";
+			id=5793;
+			atlOffset=0.00017356873;
 		};
 	};
 };

--- a/company/TRA30_Synixe_MaldenTrainingFacility.Malden/ranges/driving.sqf
+++ b/company/TRA30_Synixe_MaldenTrainingFacility.Malden/ranges/driving.sqf
@@ -1,0 +1,19 @@
+//This is the action for the First Aid Kit for players to heal themselves
+
+_fakHeal = ["Heal Yourself", "Heal Yourself", "", {player setDamage 0;}, {true}] call ace_interact_menu_fnc_createAction;
+
+[drivingFAK, 0, ["ACE_MainActions"], _fakHeal] call ace_interact_menu_fnc_addActionToObject;
+
+//This will register the position of the roadblock Hilux's so that players can reset them 
+
+private _blockHiluxPos1 = getMarkerPos "hiluxBarricade1";
+private _blockHiluxPos2 = getMarkerPos "hiluxBarricade2";
+
+_roadblockResetPos = ["Reset barricade", "Reset barricade", "", 
+{hiluxBlockVic1 setPos (getMarkerPos "hiluxBarricade1"); 
+hiluxBlockVic2 setPos (getMarkerPos "hiluxBarricade2");
+hiluxBlockVic1 setDir (getDir vic1DirSetter);
+hiluxBlockVic2 setDir (getDir vic2DirSetter);}, 
+{true}] call ace_interact_menu_fnc_createAction;
+
+[drivingLap, 0, ["ACE_MainActions"], _roadBlockResetPos] call ace_interact_menu_fnc_addActionToObject;


### PR DESCRIPTION
Adds a driving range to the training islands with space to perform a j turn, swerve maneuvers, reverse driving, ramming a barricade and some floor obstacles. Adds a variety of vehicles for it as well as a laptop to reset the barricade and a FAK for players to heal themselves